### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ let
       [{ name = "canistergeek"
       , repo = "https://github.com/usergeek/canistergeek-ic-motoko"
       , version = "v0.0.3"
-      , dependencies = [] : List Text
+      , dependencies = ["base"] : List Text
       }] : List Package
 ```
 


### PR DESCRIPTION
add `base` dependency for `canistergeek` package so `vessel verify` doesn't fail with 

```
Failed to verify "canistergeek" with:
.vessel/canistergeek/v0.0.3/src/utilsModule.mo:1.1-1.31: import error [M0010], package "base" not defined
.vessel/canistergeek/v0.0.3/src/utilsModule.mo:2.1-2.29: import error [M0010], package "base" not defined
.vessel/canistergeek/v0.0.3/src/utilsModule.mo:3.1-3.29: import error [M0010], package "base" not defined
.vessel/canistergeek/v0.0.3/src/utilsModule.mo:5.1-5.27: import error [M0010], package "base" not defined
```