### PR TITLE
remove depreciation warnings from Buffer library - bump mops to 0.0.7

### DIFF
--- a/src/calculatorModule.mo
+++ b/src/calculatorModule.mo
@@ -62,7 +62,7 @@ module {
                             calendar.addDays(-1);
                         };
                         return ?{
-                            data = #hourly (metricsDataBufferReverse.toArray());
+                            data = #hourly (Buffer.toArray(metricsDataBufferReverse));
                         };
                     };
                     case (#daily) {
@@ -99,7 +99,7 @@ module {
                             calendar.addDays(-1);
                         };
                         return ?{
-                            data = #daily (metricsDataBufferReverse.toArray());
+                            data = #daily (Buffer.toArray(metricsDataBufferReverse));
                         };
                     };
                 };

--- a/src/logger/calculatorModule.mo
+++ b/src/logger/calculatorModule.mo
@@ -130,7 +130,7 @@ module {
         };
 
         return ?{
-            data = data.toArray();
+            data = Buffer.toArray(data);
             lastAnalyzedMessageTimeNanos = lastAnalyzedMessageTimeNanos;
         };
     };

--- a/src/logger/typesModule.mo
+++ b/src/logger/typesModule.mo
@@ -129,7 +129,7 @@ module {
 
     private func prepareCurrentUpgradeData_v1(state: State): UpgradeData {
         let upgradeData : UpgradeData = #v1 {
-            queue = state.queue.toArray();
+            queue = Buffer.toArray(state.queue);
             maxCount = state.maxCount;
             next = state.next;
             full = state.full;


### PR DESCRIPTION
Replaced all instances of `.toArray()` to `Buffer.toArray()` - see: https://internetcomputer.org/docs/current/motoko/main/base/Buffer#function-toarray